### PR TITLE
ユーザー登録時の期生のバリデーションがおかしい（hotfix→mainで対応） #30

### DIFF
--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -51,7 +51,7 @@ class RegisterController extends Controller
     {
         return Validator::make($data, [
             'name' => ['required', 'string', 'max:255'],
-            'term' => ['required', 'digits:2'],
+            'term' => ['required', 'digits_between:1,2'],
             'email' => ['required', 'string', 'email', 'max:255', 'unique:users'],
             'password' => ['required', 'string', 'alpha_num', 'min:8', 'confirmed'],
         ]);


### PR DESCRIPTION
Closes #30 

ユーザー登録時の期生のバリデーションが2桁しか指定できない状態になっていたので1桁 ro 2桁に修正
