### PR TITLE
ロゴをオサレに変更 #38

### DIFF
--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -1,5 +1,0 @@
-{
-    "/js/app.js": "/js/app.js",
-    "/css/app.css": "/css/app.css",
-    "/js/articles.js": "/js/articles.js"
-}

--- a/resources/sass/style.scss
+++ b/resources/sass/style.scss
@@ -1,0 +1,5 @@
+.site-logo {
+    // googleフォント
+    font-family: 'Righteous', cursive;
+    font-size: 24px;
+}

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -5,9 +5,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no user-scalable=no">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
     <link href="{{ asset('/css/app.css') }}" rel="stylesheet">
+    <link href="{{ asset('/css/style.css') }}" rel="stylesheet">
     {{-- Bootstrapの導入は以下でもOK --}}
     {{-- <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.2.1/css/bootstrap.min.css" integrity="sha384-GJzZqFGwb1QTTN6wy59ffF1BuGJpLSa9DkKMp0DgiMDm4iYMj70gZWKYbI706tWS" crossorigin="anonymous"> --}}
     <link href="https://use.fontawesome.com/releases/v5.6.1/css/all.css" rel="stylesheet">
+    {{-- googleフォント用 --}}
+    <link rel="preconnect" href="https://fonts.gstatic.com">
+    <link href="https://fonts.googleapis.com/css2?family=Righteous&display=swap" rel="stylesheet">
     <title>
         @yield('title')
     </title>
@@ -15,7 +19,7 @@
 <body>
     <div id="app">
         <nav class="navbar navbar-expand navbar-dark bg-success text-white mb-5">
-            <a class="navbar-brand" href="{{ route('index')}}">やんばるQiita</a>
+            <a class="navbar-brand site-logo" href="{{ route('index')}}">Yanbaru Qiita</a>
             @guest
                 <ul class="navbar-nav ml-auto mr-3">
                     <li class="nav-item">

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -14,6 +14,7 @@ const mix = require('laravel-mix');
 mix.js('resources/js/app.js', 'public/js')
     .js('resources/js/articles.js', 'public/js')
     .sass('resources/sass/app.scss', 'public/css')
+    .sass('resources/sass/style.scss', 'public/css')
     .autoload({
         jquery: ['$', 'window.jQuery']
     });


### PR DESCRIPTION
Closes #38 

ロゴをオサレに変えたくらいなので軽くコード見てmergeしちゃってください〜

<img width="218" alt="スクリーンショット 2021-03-08 8 37 08" src="https://user-images.githubusercontent.com/58982088/110259152-9b078180-7fe9-11eb-8ab8-ca97c889b3ae.png">

・Laravel Mixの使い方（主に`webpack.mix.js`の書き方、Vue使うなら必須）
・Googleフォントの使い方

くらいは一応見ておいてください！
多分今後役立ちますw