### PR TITLE
Userマイページ画面のリファクタリング

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -58,8 +58,7 @@ class UserController extends Controller
      */
     public function show(User $user)
     {
-        $articles = Article::where('user_id', $user->id)->get();
-        return view('user.mypage', compact('user', 'articles'));
+        return view('user.mypage');
     }
 
     /**

--- a/app/User.php
+++ b/app/User.php
@@ -44,6 +44,4 @@ class User extends Authenticatable
     {
         return $this->hasmany('App\Article');
     }
-
-
 }

--- a/app/User.php
+++ b/app/User.php
@@ -36,4 +36,14 @@ class User extends Authenticatable
     protected $casts = [
         'email_verified_at' => 'datetime',
     ];
+
+    /**
+     * ユーザが投稿した記事を取得
+     */
+    public function articles()
+    {
+        return $this->hasmany('App\Article');
+    }
+
+
 }

--- a/resources/views/user/mypage.blade.php
+++ b/resources/views/user/mypage.blade.php
@@ -42,9 +42,7 @@
                         </div>
                         <div class="d-flex justify-content-center">
                             <a href="{{ route('index') }}" class='btn btn-secondary text-white col-md-3 py-2 mx-1 mb-4'>戻る</a>
-                            @if (auth()->user()->id === Auth::id())
-                                <a  href="{{ route('user.edit', auth()->user()) }}" class="btn btn-success text-white col-md-3 py-2 mx-1 mb-4">編集</a>
-                            @endif
+                            <a  href="{{ route('user.edit', auth()->user()) }}" class="btn btn-success text-white col-md-3 py-2 mx-1 mb-4">編集</a>
                         </div>
                     </div>
                 </div>

--- a/resources/views/user/mypage.blade.php
+++ b/resources/views/user/mypage.blade.php
@@ -25,32 +25,32 @@
                         <div class="row mb-2">
                             <p class="col-md-4 text-md-right">{{ __('Name') }}</p>
                             <p class="col-md-6">
-                                {{ $user->name }}
+                                {{ auth()->user()->name }}
                             </p>
                         </div>
                         <div class="row mb-2">
                             <p class="col-md-4 text-md-right">{{ __('Term') }}</p>
                             <p class="col-md-6">
-                                {{ $user->term }}期生
+                                {{ auth()->user()->term }}期生
                             </p>
                         </div>
                         <div class="row mb-2">
                             <p class="col-md-4 text-md-right">{{ __('Email') }}</p>
                             <p class="col-md-6">
-                                {{ $user->email }}
+                                {{ auth()->user()->email }}
                             </p>
                         </div>
                         <div class="d-flex justify-content-center">
                             <a href="{{ route('index') }}" class='btn btn-secondary text-white col-md-3 py-2 mx-1 mb-4'>戻る</a>
-                            @if ($user->id === Auth::id())
-                                <a  href="{{ route('user.edit', $user) }}" class="btn btn-success text-white col-md-3 py-2 mx-1 mb-4">編集</a>
+                            @if (auth()->user()->id === Auth::id())
+                                <a  href="{{ route('user.edit', auth()->user()) }}" class="btn btn-success text-white col-md-3 py-2 mx-1 mb-4">編集</a>
                             @endif
                         </div>
                     </div>
                 </div>
             </div>
             <h3 class="text-center mb-3">自分の投稿</h3>
-            @foreach ($articles as $article)
+            @foreach (auth()->user()->articles as $article)
                 <div class="card mb-5">
                     <div class="card-header d-flex justify-content-between align-items-center">
                         <div>


### PR DESCRIPTION
Closes # get_user_with_auth_middleware

【追加】

- User.php にユーザが投稿した記事を取得する為のリレーション

【変更】

- mypage.blade.php のユーザ情報の表示・記事の表示用の変数部分の変更
→`auth()->user()->`を使用

- UserController のshow メソッドの Eloquent によるデータ取得記述部分の削除

【特記事項】

- ユーザー及びユーザー関連記事情報を表示するのに、`auth()->user()`とリレーションを参照するように変更しました！


ご確認お願いします！
