### PR TITLE
Userマイページの認可機能の調整、URLからuserパラメータを削除

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -44,7 +44,6 @@ class UserController extends Controller
     /**
      * マイページ画面表示
      *
-     * @param  App\User  $user
      * @return \Illuminate\Http\Response
      */
     public function show()

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -11,15 +11,6 @@ use Illuminate\Support\Facades\DB;
 class UserController extends Controller
 {
     /**
-     * コンストラクタ定義
-     * ポリシーを使用できるようにする
-     */
-    public function __construct()
-    {
-        $this->authorizeResource(User::class, 'user');
-    }
-
-    /**
      * Display a listing of the resource.
      *
      * @return \Illuminate\Http\Response
@@ -56,12 +47,12 @@ class UserController extends Controller
      * @param  App\User  $user
      * @return \Illuminate\Http\Response
      */
-    public function show(User $user)
+    public function show()
     {
         return view('user.mypage');
     }
 
-    /**
+ /**
      * ユーザー情報編集画面表示
      *
      * @param  App\User  $user
@@ -69,9 +60,9 @@ class UserController extends Controller
      */
     public function edit(User $user)
     {
+        $this->authorize('update', $user);
         return view('user.edit', compact('user'));
     }
-
     /**
      * ユーザー情報編集処理
      *
@@ -81,10 +72,10 @@ class UserController extends Controller
      */
     public function update(UserRequest $request, User $user)
     {
+        $this->authorize('update', $user);
         DB::transaction(function () use ($user, $request) {
-            $user->fill($request->all())->save();            
+            $user->fill($request->all())->save();
         });
-
         return redirect()->route('user.show', $user)->with('flashMsg',  'ユーザー情報を編集しました');
     }
 

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -22,7 +22,6 @@ class UserPolicy
 
     /**
      * Determine whether the user can view the model.
-     * マイページ画面
      *
      * @param  \App\User  $user
      * @param  \App\User  $model
@@ -30,7 +29,7 @@ class UserPolicy
      */
     public function view(User $user, User $model)
     {
-        return $user->id === $model->id;
+        //
     }
 
     /**

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -37,7 +37,7 @@
                         <a class="nav-link" href="{{ route('articles.create') }}"><i class="fas fa-pen mr-2"></i>投稿する</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="{{ route('user.show', Auth::user()) }}">マイページ</a>
+                        <a class="nav-link" href="{{ route('user.show') }}">マイページ</a>
                     </li>
                     <li class="nav-item">
                         <a class="nav-link" href="javascript:logout.submit()">ログアウト</a>

--- a/routes/web.php
+++ b/routes/web.php
@@ -43,4 +43,7 @@ Auth::routes();
  * ユーザー
  */
 //CRUD用
-Route::resource('user', 'UserController')->only(['edit', 'update', 'show'])->middleware('auth');
+Route::group(['middleware' => 'auth'], function () {
+    Route::resource('user', 'UserController')->only(['edit', 'update']);
+    Route::get('/user', 'UserController@show')->name('user.show');
+});


### PR DESCRIPTION
**<<マイページ画面の表示変更>>**

【追加】

- なし

【変更】

- マイページ表示時にURLにパラメータを使わない
- ヘッダーの「マイページ」から画面遷移する時に認証済みユーザ情報をURLクエリに含ませない
- resourceメソッドのルーティングからshowメソッド削除
- 代わりにGETメソッドのルーティング作成
- 上記2つのルーティングは ミドルウェアでグループにまとめる
- UserControllerのshowメソッドにUserモデルのインスタンスをDIさせない
- UserPolicyのviewメソッドの削除
- UserControllerからauthorizeResourceメソッドを削除し各メソッドで個別に認可を定義する

【特記事項】

- UserControllerのshowメソッドは認可機能を実装していません。
- 他のユーザID でマイページの表示は不可でした。