### PR TITLE
passwordのバリデーションを正規表現に変更

### DIFF
--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -53,7 +53,7 @@ class RegisterController extends Controller
             'name' => ['required', 'string', 'max:255'],
             'term' => ['required', 'digits_between:1,2'],
             'email' => ['required', 'string', 'email', 'max:255', 'unique:users'],
-            'password' => ['required', 'string', 'regex:^([a-zA-Z0-9]{8,})$^', 'confirmed'],
+            'password' => ['required', 'string', 'regex:/^([a-zA-Z0-9]{8,})+$/u', 'confirmed'],
         ]);
     }
 

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -53,7 +53,7 @@ class RegisterController extends Controller
             'name' => ['required', 'string', 'max:255'],
             'term' => ['required', 'digits_between:1,2'],
             'email' => ['required', 'string', 'email', 'max:255', 'unique:users'],
-            'password' => ['required', 'string', 'alpha_num', 'min:8', 'confirmed'],
+            'password' => ['required', 'string', 'regex:^([a-zA-Z0-9]{8,})$^', 'confirmed'],
         ]);
     }
 


### PR DESCRIPTION
`RegisterController.php` の`password`のバリデーション修正です

【追加】

- なし

【変更】

- alpha系のバリデーションは全角日本語が通ってしまうので正規表現にしました！

【削除】

- `min:8`を削除し、8文字以上の条件も正規表現にまとめました！

【特記事項】

- 全角日本語のかな・カタカナ・漢字の登録が、不可なのを確認しました。
- 8文字以下の登録が、不可なのを確認しました。

ご確認宜しくお願いします🙇